### PR TITLE
Plug-in real database, fix Link serialization

### DIFF
--- a/orchestrator/pipelines/newspaper_crawl.py
+++ b/orchestrator/pipelines/newspaper_crawl.py
@@ -2,7 +2,7 @@ from steps.craw_links import crawl_links
 from zenml import pipeline
 
 
-@pipeline
+@pipeline(enable_cache=False)
 def crawl(newspapers_urls: list[str]):
     last_step = crawl_links(newspapers_urls)
     return last_step.invocation_id

--- a/src/news_summarizer/config/_base.py
+++ b/src/news_summarizer/config/_base.py
@@ -15,6 +15,7 @@ class HuggingFaceSettings(BaseSettings):
 
 class MongoSettings(BaseSettings):
     model_config = SettingsConfigDict(env=".env", env_prefix="MONGO_")
+    name: str = Field("name", json_schema_extra={"env": "NAME"})
     username: str = Field("user", json_schema_extra={"env": "USERNAME"})
     password: SecretStr = Field("pass", json_schema_extra={"env": "PASSWORD"})
     host: str = Field("localhost", json_schema_extra={"env": "HOST"})

--- a/src/news_summarizer/crawler/registry.py
+++ b/src/news_summarizer/crawler/registry.py
@@ -4,6 +4,7 @@ import re
 from .base import BaseCrawler
 from .newspaper_website import BandCrawler, G1Crawler, R7Crawler
 
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/src/news_summarizer/database/mongo.py
+++ b/src/news_summarizer/database/mongo.py
@@ -5,6 +5,7 @@ from news_summarizer.config import settings
 from pymongo import MongoClient
 from pymongo.errors import ConnectionFailure
 
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -98,5 +99,3 @@ class MongoDatabaseConnector:
 
 
 connection = MongoDatabaseConnector()
-
-fake_connection = FakeMongoClient()

--- a/src/news_summarizer/domain/documents.py
+++ b/src/news_summarizer/domain/documents.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import AnyUrl, Field
+from pydantic import AnyUrl, Field, field_serializer
 
 from .base import NoSQLBaseLink
 
@@ -15,6 +15,10 @@ class Link(NoSQLBaseLink):
         default_factory=datetime.now,
         description="The timestamp when the link was extracted",
     )
+
+    @field_serializer("url")
+    def url_string(self, url: AnyUrl):
+        return str(url)
 
     class Settings:
         name = "link"

--- a/tests/unit/domain/test_documents.py
+++ b/tests/unit/domain/test_documents.py
@@ -62,12 +62,12 @@ def test_link_save(mock_database):
 
     assert found_link is not None
     assert found_link["title"] == "Sample Link"
-    assert found_link["url"] == AnyUrl("http://example.com")
+    assert found_link["url"] == "http://example.com/"
 
 
 def test_link_get_or_create(mock_database):
     # Create a new link
-    link = Link.get_or_create(title="New Link", url=AnyUrl("http://example.com"))
+    link = Link.get_or_create(title="New Link", url="http://example.com")
     link_uuid = link.id
 
     # Ensure the link was saved
@@ -76,10 +76,10 @@ def test_link_get_or_create(mock_database):
 
     assert found_link is not None
     assert found_link["title"] == "New Link"
-    assert found_link["url"] == AnyUrl("http://example.com")
+    assert found_link["url"] == "http://example.com/"
 
     # Retrieve the same link without creating a new one
-    same_link = Link.get_or_create(title="New Link", url=AnyUrl("http://example.com"))
+    same_link = Link.get_or_create(title="New Link", url="http://example.com/")
     assert same_link.id == link_uuid
 
 


### PR DESCRIPTION
## Summary
This pull request integrates a real MongoDB database running in a Docker container and solves a serialization issue with the `Link` model. Specifically, it addresses the incompatibility of Pydantic v2's `AnyUrl` field with `Mongo` by adding a `@field_serializer` to convert URLs to strings during serialization.

## Changes
- Integrated a real MongoDB database with Docker support.
- Updated the `Link` model to include a `@field_serializer` for the `url` field, ensuring `AnyUrl` values are serialized as strings.
- Fixed serialization issues related to `AnyUrl` fields in Pydantic v2.

### Updated `Link` Model
Previous implementation:
```python
from datetime import datetime
from typing import Optional
from pydantic import AnyUrl, Field
from .base import NoSQLBaseLink

class Link(NoSQLBaseLink):
    title: str = Field(..., description="The title of the link")
    url: AnyUrl = Field(description="The URL of the link")
    source: Optional[str] = Field(None, description="The source of the link")
    published_at: Optional[datetime] = Field(None, description="The publication date of the link")
    extracted_at: datetime = Field(
        default_factory=datetime.now,
        description="The timestamp when the link was extracted",
    )
    class Settings:
        name = "link"
